### PR TITLE
fix: missing `RestoreWindowsConsole` & `EnableWindowsANSIConsole`

### DIFF
--- a/terminal/color_enable_windows.go
+++ b/terminal/color_enable_windows.go
@@ -15,9 +15,9 @@ import (
 func EnableColor(file *os.File) (bool, CleanupFunc, error) {
 	output := termenv.NewOutput(file)
 	if output.EnvColorProfile() != termenv.Ascii {
-		if mode, err := output.EnableWindowsANSIConsole(); err == nil {
+		if mode, err := termenv.EnableWindowsANSIConsole(); err == nil {
 			return true, func() error {
-				return output.RestoreWindowsConsole(mode)
+				return termenv.RestoreWindowsConsole(mode)
 			}, nil
 		} else {
 			return false, nil, err


### PR DESCRIPTION
Hi, `termenv` has made its functions (`RestoreWindowsConsole` & `EnableWindowsANSIConsole`) without receivers, therefore non-fixed codes may lead to compile failed.

refer: https://github.com/muesli/termenv/blob/d7b2104cccafd2c5062870c5c2b6a259f1e9cb0a/termenv_windows.go#L63